### PR TITLE
chore: bump spring boot 4.1.0 and fix ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,3 @@
-# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs.
-# Requires EditorConfig JetBrains Plugin - http://github.com/editorconfig/editorconfig-jetbrains
-
-# Set this file as the topmost .editorconfig
-# (multiple files can be used, and are applied starting from current document location)
 root = true
 
 [*]
@@ -13,8 +8,18 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{kt,kts}]
-max_line_length = 140
+[*.md]
+trim_trailing_whitespace = false
 
 [*.{xml,yaml,yml,json}]
 indent_size = 2
+
+[*.{kt,kts}]
+ktlint_code_style = intellij_idea
+
+max_line_length = 140
+
+# No star imports
+ij_kotlin_packages_to_use_import_on_demand = unset
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,13 +5,16 @@
 # (multiple files can be used, and are applied starting from current document location)
 root = true
 
-# Use bracketed regexp to target specific file types or file locations
-
-[*.{kt,java,json}]
-indent_style = space
-end_of_line = lf
+[*]
 charset = utf-8
-trim_trailing_whitespace = true
+end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
 indent_size = 4
 
+[*.{kt,kts}]
+max_line_length = 140
+
+[*.{xml,yaml,yml,json}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ The API documentation is available at ```src/main/resources/specification```.
 ```sh
 mvn verify
 ```
+
+### Formatting code
+
+This project uses [ktlint](https://github.com/gantsign/ktlint-maven-plugin) to enforce a consistent code style.
+To automatically fix formatting violations, run:
+
+```sh
+mvn ktlint:format
+```

--- a/pom.xml
+++ b/pom.xml
@@ -282,18 +282,14 @@
                 </configuration>
             </plugin>
 
-            <!-- ktlint derives its source roots from the project's compile source roots.
-                 Those are set to src/main/kotlin and src/test/kotlin by <sourceDirectory>
-                 and <testSourceDirectory> above, so ktlint sees all Kotlin sources. -->
             <plugin>
                 <groupId>com.github.gantsign.maven</groupId>
                 <artifactId>ktlint-maven-plugin</artifactId>
                 <version>${ktlint.version}</version>
                 <executions>
                     <execution>
-                        <id>format-and-check</id>
+                        <id>ktlint-check</id>
                         <goals>
-                            <goal>format</goal>
                             <goal>check</goal>
                         </goals>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -35,6 +35,9 @@
         <kotlin.version>2.2.21</kotlin.version>
         <testcontainers.version>2.0.4</testcontainers.version>
         <jena.version>6.0.0</jena.version>
+        <ktlint.version>3.7.1</ktlint.version>
+        <!-- Overrides Spring Boot 4.1.0 (42.7.11), which is still affected by CVE-2026-54291 -->
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
     <dependencies>
@@ -279,20 +282,23 @@
                 </configuration>
             </plugin>
 
-        <plugin>
-            <groupId>com.github.gantsign.maven</groupId>
-            <artifactId>ktlint-maven-plugin</artifactId>
-            <version>3.5.0</version>
-            <executions>
-                <execution>
-                    <id>format-and-check</id>
-                    <goals>
-                        <goal>format</goal>
-                        <goal>check</goal>
-                    </goals>
-                </execution>
-            </executions>
-        </plugin>
+            <!-- ktlint derives its source roots from the project's compile source roots.
+                 Those are set to src/main/kotlin and src/test/kotlin by <sourceDirectory>
+                 and <testSourceDirectory> above, so ktlint sees all Kotlin sources. -->
+            <plugin>
+                <groupId>com.github.gantsign.maven</groupId>
+                <artifactId>ktlint-maven-plugin</artifactId>
+                <version>${ktlint.version}</version>
+                <executions>
+                    <execution>
+                        <id>format-and-check</id>
+                        <goals>
+                            <goal>format</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/main/kotlin/no/digdir/organizationcatalog/adapter/EnhetsregisteretAdapter.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/adapter/EnhetsregisteretAdapter.kt
@@ -20,9 +20,7 @@ import java.net.URI
 private val LOGGER = LoggerFactory.getLogger(EnhetsregisteretAdapter::class.java)
 
 @Component
-class EnhetsregisteretAdapter(
-    private val appProperties: AppProperties,
-) {
+class EnhetsregisteretAdapter(private val appProperties: AppProperties) {
     fun getOrganizationAndParents(organizationId: String): List<EnhetsregisteretOrganization> {
         LOGGER.info("Downloading data regarding '$organizationId' from Enhetsregisteret")
         return downloadAndParseOrganization(organizationId)
@@ -30,13 +28,12 @@ class EnhetsregisteretAdapter(
             ?: emptyList()
     }
 
-    private fun downloadAndParseOrganization(organizationId: String): EnhetsregisteretOrganization? =
-        runBlocking {
-            val organizationPromise = async { getOrganizationFromEnhetsregisteret(organizationId) }
-            val subordinateOrganizationPromise = async { getOrganizationFromEnhetsregisteret(organizationId, true) }
+    private fun downloadAndParseOrganization(organizationId: String): EnhetsregisteretOrganization? = runBlocking {
+        val organizationPromise = async { getOrganizationFromEnhetsregisteret(organizationId) }
+        val subordinateOrganizationPromise = async { getOrganizationFromEnhetsregisteret(organizationId, true) }
 
-            organizationPromise.await() ?: subordinateOrganizationPromise.await()
-        }
+        organizationPromise.await() ?: subordinateOrganizationPromise.await()
+    }
 
     private fun EnhetsregisteretOrganization.downloadParentOrgsAndCreateOrgPath(): List<EnhetsregisteretOrganization> {
         val orgList: MutableList<EnhetsregisteretOrganization> = mutableListOf(this)
@@ -136,7 +133,6 @@ class EnhetsregisteretAdapter(
             ?.enheter
             ?: emptyList()
 
-    private fun isTestEnvironment(): Boolean =
-        setOf("localhost", "staging", "demo")
-            .any { it in appProperties.organizationCatalogUrl }
+    private fun isTestEnvironment(): Boolean = setOf("localhost", "staging", "demo")
+        .any { it in appProperties.organizationCatalogUrl }
 }

--- a/src/main/kotlin/no/digdir/organizationcatalog/adapter/TransportOrganizationAdapter.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/adapter/TransportOrganizationAdapter.kt
@@ -17,31 +17,29 @@ class TransportOrganizationAdapter(
     @Value("\${application.enturHeaderKey}") val enturHeaderKey: String,
     @Value("\${application.enturHeaderValue}") val enturHeaderValue: String,
 ) {
-    fun downloadTransportDataList(): List<TransportOrganization> =
-        downloadTransportDataRaw()
-            ?.let { it.transformToTransportDataList() }
-            ?.distinctBy { it.companyNumber } ?: emptyList()
+    fun downloadTransportDataList(): List<TransportOrganization> = downloadTransportDataRaw()
+        ?.let { it.transformToTransportDataList() }
+        ?.distinctBy { it.companyNumber } ?: emptyList()
 
-    fun downloadTransportDataRaw(): String? =
-        URI(enturDataUrl)
-            .toURL()
-            .openConnection()
-            .run {
-                this as HttpURLConnection
-                this.setRequestProperty(enturHeaderKey, enturHeaderValue)
+    fun downloadTransportDataRaw(): String? = URI(enturDataUrl)
+        .toURL()
+        .openConnection()
+        .run {
+            this as HttpURLConnection
+            this.setRequestProperty(enturHeaderKey, enturHeaderValue)
 
-                if (responseCode != HttpStatus.OK.value()) {
-                    logger.error("Download of transport data failed with code $responseCode")
-                    return@run null
-                }
-
-                try {
-                    inputStream.bufferedReader().use { reader ->
-                        reader.readText()
-                    }
-                } catch (ex: Exception) {
-                    logger.error("Error reading downloaded data : ${ex.message}")
-                    null
-                }
+            if (responseCode != HttpStatus.OK.value()) {
+                logger.error("Download of transport data failed with code $responseCode")
+                return@run null
             }
+
+            try {
+                inputStream.bufferedReader().use { reader ->
+                    reader.readText()
+                }
+            } catch (ex: Exception) {
+                logger.error("Error reading downloaded data : ${ex.message}")
+                null
+            }
+        }
 }

--- a/src/main/kotlin/no/digdir/organizationcatalog/configuration/BrregForwardingFilter.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/configuration/BrregForwardingFilter.kt
@@ -14,14 +14,8 @@ import org.springframework.stereotype.Component
 private val LOGGER = LoggerFactory.getLogger(BrregForwardingFilter::class.java)
 
 @Component
-class BrregForwardingFilter(
-    private val appProperties: AppProperties,
-) : Filter {
-    override fun doFilter(
-        request: ServletRequest?,
-        response: ServletResponse?,
-        chain: FilterChain?,
-    ) {
+class BrregForwardingFilter(private val appProperties: AppProperties) : Filter {
+    override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
         if (request != null && response != null && chain != null) {
             try {
                 val httpRequest = request as HttpServletRequest

--- a/src/main/kotlin/no/digdir/organizationcatalog/configuration/JacksonConfiguration.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/configuration/JacksonConfiguration.kt
@@ -8,8 +8,7 @@ import tools.jackson.databind.DeserializationFeature
 @Configuration
 class JacksonConfiguration {
     @Bean
-    fun disableFailOnNullForPrimitives(): JsonMapperBuilderCustomizer =
-        JsonMapperBuilderCustomizer { builder ->
-            builder.disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
-        }
+    fun disableFailOnNullForPrimitives(): JsonMapperBuilderCustomizer = JsonMapperBuilderCustomizer { builder ->
+        builder.disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+    }
 }

--- a/src/main/kotlin/no/digdir/organizationcatalog/controller/AdminController.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/controller/AdminController.kt
@@ -15,40 +15,28 @@ import org.springframework.web.bind.annotation.RestController
 @CrossOrigin
 @RestController
 @RequestMapping("/admin")
-open class AdminController(
-    private val catalogService: OrganizationCatalogService,
-    private val endpointPermissions: EndpointPermissions,
-) {
+open class AdminController(private val catalogService: OrganizationCatalogService, private val endpointPermissions: EndpointPermissions) {
     @PostMapping("/update/stat", produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun updateSTAT(
-        @AuthenticationPrincipal jwt: Jwt,
-    ): ResponseEntity<Any> =
-        if (endpointPermissions.hasAdminPermission(jwt)) {
-            catalogService.updateSTAT()
-            ResponseEntity(HttpStatus.OK)
-        } else {
-            ResponseEntity(HttpStatus.FORBIDDEN)
-        }
+    fun updateSTAT(@AuthenticationPrincipal jwt: Jwt): ResponseEntity<Any> = if (endpointPermissions.hasAdminPermission(jwt)) {
+        catalogService.updateSTAT()
+        ResponseEntity(HttpStatus.OK)
+    } else {
+        ResponseEntity(HttpStatus.FORBIDDEN)
+    }
 
     @PostMapping("/update/fylk", produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun updateFYLK(
-        @AuthenticationPrincipal jwt: Jwt,
-    ): ResponseEntity<Any> =
-        if (endpointPermissions.hasAdminPermission(jwt)) {
-            catalogService.updateFYLK()
-            ResponseEntity(HttpStatus.OK)
-        } else {
-            ResponseEntity(HttpStatus.FORBIDDEN)
-        }
+    fun updateFYLK(@AuthenticationPrincipal jwt: Jwt): ResponseEntity<Any> = if (endpointPermissions.hasAdminPermission(jwt)) {
+        catalogService.updateFYLK()
+        ResponseEntity(HttpStatus.OK)
+    } else {
+        ResponseEntity(HttpStatus.FORBIDDEN)
+    }
 
     @PostMapping("/update/komm", produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun updateKOMM(
-        @AuthenticationPrincipal jwt: Jwt,
-    ): ResponseEntity<Any> =
-        if (endpointPermissions.hasAdminPermission(jwt)) {
-            catalogService.updateKOMM()
-            ResponseEntity(HttpStatus.OK)
-        } else {
-            ResponseEntity(HttpStatus.FORBIDDEN)
-        }
+    fun updateKOMM(@AuthenticationPrincipal jwt: Jwt): ResponseEntity<Any> = if (endpointPermissions.hasAdminPermission(jwt)) {
+        catalogService.updateKOMM()
+        ResponseEntity(HttpStatus.OK)
+    } else {
+        ResponseEntity(HttpStatus.FORBIDDEN)
+    }
 }

--- a/src/main/kotlin/no/digdir/organizationcatalog/controller/OrganizationsController.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/controller/OrganizationsController.kt
@@ -47,8 +47,14 @@ open class OrganizationsController(
         @RequestBody organization: Organization,
     ): ResponseEntity<Organization> =
         when {
-            !id.isOrganizationNumber() -> ResponseEntity(HttpStatus.BAD_REQUEST)
-            !endpointPermissions.hasAdminPermission(jwt) -> ResponseEntity(HttpStatus.FORBIDDEN)
+            !id.isOrganizationNumber() -> {
+                ResponseEntity(HttpStatus.BAD_REQUEST)
+            }
+
+            !endpointPermissions.hasAdminPermission(jwt) -> {
+                ResponseEntity(HttpStatus.FORBIDDEN)
+            }
+
             else -> {
                 try {
                     LOGGER.debug("update organization $id")
@@ -59,12 +65,22 @@ open class OrganizationsController(
                 } catch (exception: Exception) {
                     LOGGER.error("error updating organization $id", exception)
                     when {
-                        exception is ConstraintViolationException -> ResponseEntity<Organization>(HttpStatus.BAD_REQUEST)
-                        exception is TransactionSystemException &&
-                            exception.rootCause is ConstraintViolationException ->
+                        exception is ConstraintViolationException -> {
                             ResponseEntity<Organization>(HttpStatus.BAD_REQUEST)
-                        exception is DataIntegrityViolationException -> ResponseEntity(HttpStatus.CONFLICT)
-                        else -> ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR)
+                        }
+
+                        exception is TransactionSystemException &&
+                            exception.rootCause is ConstraintViolationException -> {
+                            ResponseEntity<Organization>(HttpStatus.BAD_REQUEST)
+                        }
+
+                        exception is DataIntegrityViolationException -> {
+                            ResponseEntity(HttpStatus.CONFLICT)
+                        }
+
+                        else -> {
+                            ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR)
+                        }
                     }
                 }
             }
@@ -151,8 +167,14 @@ open class OrganizationsController(
         @PathVariable id: String,
     ): ResponseEntity<Organization> =
         when {
-            !id.isOrganizationNumber() -> ResponseEntity(HttpStatus.BAD_REQUEST)
-            !endpointPermissions.hasAdminPermission(jwt) -> ResponseEntity(HttpStatus.FORBIDDEN)
+            !id.isOrganizationNumber() -> {
+                ResponseEntity(HttpStatus.BAD_REQUEST)
+            }
+
+            !endpointPermissions.hasAdminPermission(jwt) -> {
+                ResponseEntity(HttpStatus.FORBIDDEN)
+            }
+
             else -> {
                 LOGGER.debug("update organization with id $id with data from Enhetsregisteret")
                 catalogService

--- a/src/main/kotlin/no/digdir/organizationcatalog/controller/OrganizationsController.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/controller/OrganizationsController.kt
@@ -45,46 +45,45 @@ open class OrganizationsController(
         @AuthenticationPrincipal jwt: Jwt,
         @PathVariable id: String,
         @RequestBody organization: Organization,
-    ): ResponseEntity<Organization> =
-        when {
-            !id.isOrganizationNumber() -> {
-                ResponseEntity(HttpStatus.BAD_REQUEST)
-            }
+    ): ResponseEntity<Organization> = when {
+        !id.isOrganizationNumber() -> {
+            ResponseEntity(HttpStatus.BAD_REQUEST)
+        }
 
-            !endpointPermissions.hasAdminPermission(jwt) -> {
-                ResponseEntity(HttpStatus.FORBIDDEN)
-            }
+        !endpointPermissions.hasAdminPermission(jwt) -> {
+            ResponseEntity(HttpStatus.FORBIDDEN)
+        }
 
-            else -> {
-                try {
-                    LOGGER.debug("update organization $id")
-                    catalogService
-                        .updateEntry(id, organization)
-                        ?.let { updated -> ResponseEntity(updated, HttpStatus.OK) }
-                        ?: ResponseEntity(HttpStatus.NOT_FOUND)
-                } catch (exception: Exception) {
-                    LOGGER.error("error updating organization $id", exception)
-                    when {
-                        exception is ConstraintViolationException -> {
-                            ResponseEntity<Organization>(HttpStatus.BAD_REQUEST)
-                        }
+        else -> {
+            try {
+                LOGGER.debug("update organization $id")
+                catalogService
+                    .updateEntry(id, organization)
+                    ?.let { updated -> ResponseEntity(updated, HttpStatus.OK) }
+                    ?: ResponseEntity(HttpStatus.NOT_FOUND)
+            } catch (exception: Exception) {
+                LOGGER.error("error updating organization $id", exception)
+                when {
+                    exception is ConstraintViolationException -> {
+                        ResponseEntity<Organization>(HttpStatus.BAD_REQUEST)
+                    }
 
-                        exception is TransactionSystemException &&
-                            exception.rootCause is ConstraintViolationException -> {
-                            ResponseEntity<Organization>(HttpStatus.BAD_REQUEST)
-                        }
+                    exception is TransactionSystemException &&
+                        exception.rootCause is ConstraintViolationException -> {
+                        ResponseEntity<Organization>(HttpStatus.BAD_REQUEST)
+                    }
 
-                        exception is DataIntegrityViolationException -> {
-                            ResponseEntity(HttpStatus.CONFLICT)
-                        }
+                    exception is DataIntegrityViolationException -> {
+                        ResponseEntity(HttpStatus.CONFLICT)
+                    }
 
-                        else -> {
-                            ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR)
-                        }
+                    else -> {
+                        ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR)
                     }
                 }
             }
         }
+    }
 
     @GetMapping(
         "/{id}",
@@ -97,10 +96,7 @@ open class OrganizationsController(
             "text/turtle",
         ],
     )
-    fun getOrganizationById(
-        @RequestHeader(HttpHeaders.ACCEPT) accept: String?,
-        @PathVariable id: String,
-    ): ResponseEntity<Any> {
+    fun getOrganizationById(@RequestHeader(HttpHeaders.ACCEPT) accept: String?, @PathVariable id: String): ResponseEntity<Any> {
         if (!id.isOrganizationNumber()) {
             return ResponseEntity(HttpStatus.BAD_REQUEST)
         } else {
@@ -162,32 +158,26 @@ open class OrganizationsController(
     }
 
     @PostMapping("/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun updateFromEnhetsregisteret(
-        @AuthenticationPrincipal jwt: Jwt,
-        @PathVariable id: String,
-    ): ResponseEntity<Organization> =
-        when {
-            !id.isOrganizationNumber() -> {
-                ResponseEntity(HttpStatus.BAD_REQUEST)
-            }
-
-            !endpointPermissions.hasAdminPermission(jwt) -> {
-                ResponseEntity(HttpStatus.FORBIDDEN)
-            }
-
-            else -> {
-                LOGGER.debug("update organization with id $id with data from Enhetsregisteret")
-                catalogService
-                    .updateEntryFromEnhetsregisteret(id)
-                    ?.let { updated -> ResponseEntity(updated, HttpStatus.OK) }
-                    ?: ResponseEntity(HttpStatus.NOT_FOUND)
-            }
+    fun updateFromEnhetsregisteret(@AuthenticationPrincipal jwt: Jwt, @PathVariable id: String): ResponseEntity<Organization> = when {
+        !id.isOrganizationNumber() -> {
+            ResponseEntity(HttpStatus.BAD_REQUEST)
         }
 
+        !endpointPermissions.hasAdminPermission(jwt) -> {
+            ResponseEntity(HttpStatus.FORBIDDEN)
+        }
+
+        else -> {
+            LOGGER.debug("update organization with id $id with data from Enhetsregisteret")
+            catalogService
+                .updateEntryFromEnhetsregisteret(id)
+                ?.let { updated -> ResponseEntity(updated, HttpStatus.OK) }
+                ?: ResponseEntity(HttpStatus.NOT_FOUND)
+        }
+    }
+
     @GetMapping("/orgpath/{org}", produces = [MediaType.TEXT_PLAIN_VALUE])
-    fun getOrgPath(
-        @PathVariable org: String,
-    ): ResponseEntity<String> {
+    fun getOrgPath(@PathVariable org: String): ResponseEntity<String> {
         LOGGER.debug("get orgPath for $org")
         return ResponseEntity(catalogService.getOrgPath(org), HttpStatus.OK)
     }

--- a/src/main/kotlin/no/digdir/organizationcatalog/jena/JenaUtils.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/jena/JenaUtils.kt
@@ -17,15 +17,10 @@ import org.apache.jena.vocabulary.SKOS
 import java.io.ByteArrayOutputStream
 import java.net.URI
 
-fun Organization.jenaResponse(
-    responseType: JenaType,
-    urls: ExternalUrls,
-): String = listOf(this).jenaResponse(responseType, urls)
+fun Organization.jenaResponse(responseType: JenaType, urls: ExternalUrls): String = listOf(this).jenaResponse(responseType, urls)
 
-fun List<Organization>.jenaResponse(
-    responseType: JenaType,
-    urls: ExternalUrls,
-): String = createModel(urls).createResponseString(responseType)
+fun List<Organization>.jenaResponse(responseType: JenaType, urls: ExternalUrls): String =
+    createModel(urls).createResponseString(responseType)
 
 private fun List<Organization>.createModel(urls: ExternalUrls): Model {
     val model = ModelFactory.createDefaultModel()
@@ -68,57 +63,45 @@ private fun List<Organization>.createModel(urls: ExternalUrls): Model {
     return model
 }
 
-private fun Resource.addRegistration(org: Organization): Resource =
-    addProperty(
-        ROV.registration,
-        model
-            .createResource(ADMS.Identifier)
-            .safeAddProperty(DCTerms.issued, org.issued?.toString())
-            .addProperty(SKOS.notation, org.organizationId)
-            .addProperty(ADMS.schemaAgency, "Brønnøysundregistrene"),
-    )
+private fun Resource.addRegistration(org: Organization): Resource = addProperty(
+    ROV.registration,
+    model
+        .createResource(ADMS.Identifier)
+        .safeAddProperty(DCTerms.issued, org.issued?.toString())
+        .addProperty(SKOS.notation, org.organizationId)
+        .addProperty(ADMS.schemaAgency, "Brønnøysundregistrene"),
+)
 
-private fun Resource.addOrgType(orgType: String?): Resource =
-    if (orgType == null) {
-        this
-    } else {
-        safeAddLinkedProperty(ROV.orgType, "${ORGTYPE.URI}$orgType")
-    }
+private fun Resource.addOrgType(orgType: String?): Resource = if (orgType == null) {
+    this
+} else {
+    safeAddLinkedProperty(ROV.orgType, "${ORGTYPE.URI}$orgType")
+}
 
-private fun Resource.safeAddProperty(
-    property: Property,
-    value: String?,
-): Resource =
-    if (value == null) {
-        this
-    } else {
-        addProperty(property, value)
-    }
+private fun Resource.safeAddProperty(property: Property, value: String?): Resource = if (value == null) {
+    this
+} else {
+    addProperty(property, value)
+}
 
-private fun Resource.safeAddLinkedProperty(
-    property: Property,
-    value: String?,
-): Resource =
-    if (value == null) {
-        this
-    } else {
-        addProperty(property, model.createResource(value))
-    }
+private fun Resource.safeAddLinkedProperty(property: Property, value: String?): Resource = if (value == null) {
+    this
+} else {
+    addProperty(property, model.createResource(value))
+}
 
-private fun String.isWellFormedIRI(): Boolean =
-    try {
-        URI.create(this).isAbsolute
-    } catch (ex: Exception) {
-        false
-    }
+private fun String.isWellFormedIRI(): Boolean = try {
+    URI.create(this).isAbsolute
+} catch (ex: Exception) {
+    false
+}
 
-private fun Resource.safeAddHomepage(value: String?): Resource =
-    when {
-        value == null -> this
-        value.isWellFormedIRI() -> addProperty(FOAF.homepage, model.createResource(value))
-        "http://$value".isWellFormedIRI() -> addProperty(FOAF.homepage, model.createResource("http://$value"))
-        else -> this
-    }
+private fun Resource.safeAddHomepage(value: String?): Resource = when {
+    value == null -> this
+    value.isWellFormedIRI() -> addProperty(FOAF.homepage, model.createResource(value))
+    "http://$value".isWellFormedIRI() -> addProperty(FOAF.homepage, model.createResource("http://$value"))
+    else -> this
+}
 
 private fun Resource.addPreferredNames(preferredNames: PrefLabel?): Resource {
     if (preferredNames?.nb != null) addProperty(FOAF.name, preferredNames.nb, "nb")
@@ -135,29 +118,25 @@ private fun Resource.addOrgStatus(orgStatus: OrgStatus?): Resource {
     return this
 }
 
-private fun Model.createResponseString(responseType: JenaType): String =
-    ByteArrayOutputStream().use { out ->
-        write(out, responseType.value)
-        out.flush()
-        out.toString("UTF-8")
-    }
+private fun Model.createResponseString(responseType: JenaType): String = ByteArrayOutputStream().use { out ->
+    write(out, responseType.value)
+    out.flush()
+    out.toString("UTF-8")
+}
 
-fun acceptHeaderToJenaType(accept: String?): JenaType =
-    when {
-        accept == null -> JenaType.TURTLE
-        accept.contains("text/turtle") -> JenaType.TURTLE
-        accept.contains("application/rdf+xml") -> JenaType.RDF_XML
-        accept.contains("application/rdf+json") -> JenaType.RDF_JSON
-        accept.contains("application/ld+json") -> JenaType.JSON_LD
-        accept.contains("application/xml") -> JenaType.NOT_JENA
-        accept.contains("application/json") -> JenaType.NOT_JENA
-        accept.contains("*/*") -> JenaType.TURTLE
-        else -> JenaType.NOT_ACCEPTABLE
-    }
+fun acceptHeaderToJenaType(accept: String?): JenaType = when {
+    accept == null -> JenaType.TURTLE
+    accept.contains("text/turtle") -> JenaType.TURTLE
+    accept.contains("application/rdf+xml") -> JenaType.RDF_XML
+    accept.contains("application/rdf+json") -> JenaType.RDF_JSON
+    accept.contains("application/ld+json") -> JenaType.JSON_LD
+    accept.contains("application/xml") -> JenaType.NOT_JENA
+    accept.contains("application/json") -> JenaType.NOT_JENA
+    accept.contains("*/*") -> JenaType.TURTLE
+    else -> JenaType.NOT_ACCEPTABLE
+}
 
-enum class JenaType(
-    val value: String,
-) {
+enum class JenaType(val value: String) {
     TURTLE("TURTLE"),
     RDF_XML("RDF/XML"),
     RDF_JSON("RDF/JSON"),
@@ -166,7 +145,4 @@ enum class JenaType(
     NOT_ACCEPTABLE(""),
 }
 
-data class ExternalUrls(
-    val organizationCatalog: String? = null,
-    val municipality: String? = null,
-)
+data class ExternalUrls(val organizationCatalog: String? = null, val municipality: String? = null)

--- a/src/main/kotlin/no/digdir/organizationcatalog/mapping/Mappers.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/mapping/Mappers.kt
@@ -14,57 +14,54 @@ import no.digdir.organizationcatalog.utils.prefLabelFromName
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-fun OrganizationDB.mapToGenerated(enhetsregisteretUrl: String): Organization =
-    Organization(
-        name = name,
-        norwegianRegistry = enhetsregisteretUrl + organizationId,
-        internationalRegistry = internationalRegistry,
-        organizationId = organizationId,
-        orgType = orgType,
-        orgPath = orgPath,
-        subOrganizationOf = subOrganizationOf,
-        issued = issued,
-        municipalityNumber = municipalityNumber,
-        industryCode = industryCode,
-        sectorCode = sectorCode,
-        prefLabel = prefLabel?.toPrefLabel(),
-        orgStatus = orgStatus,
-        homepage = homepage,
-        subordinate = subordinate,
-    )
+fun OrganizationDB.mapToGenerated(enhetsregisteretUrl: String): Organization = Organization(
+    name = name,
+    norwegianRegistry = enhetsregisteretUrl + organizationId,
+    internationalRegistry = internationalRegistry,
+    organizationId = organizationId,
+    orgType = orgType,
+    orgPath = orgPath,
+    subOrganizationOf = subOrganizationOf,
+    issued = issued,
+    municipalityNumber = municipalityNumber,
+    industryCode = industryCode,
+    sectorCode = sectorCode,
+    prefLabel = prefLabel?.toPrefLabel(),
+    orgStatus = orgStatus,
+    homepage = homepage,
+    subordinate = subordinate,
+)
 
-fun EnhetsregisteretOrganization.mapForCreation(): OrganizationDB =
-    OrganizationDB(
-        name = navn,
-        organizationId = organisasjonsnummer,
-        orgType = organisasjonsform?.kode,
-        orgPath = orgPath,
-        subOrganizationOf = overordnetEnhet,
-        municipalityNumber = forretningsadresse?.kommunenummer ?: postadresse?.kommunenummer,
-        issued = registreringsdatoEnhetsregisteret?.let { LocalDate.parse(it) },
-        industryCode = naeringskode1?.kode,
-        sectorCode = institusjonellSektorkode?.kode,
-        homepage = hjemmeside,
-        orgStatus = orgStatusFromDeleteDate(),
-        prefLabel = navn.prefLabelFromName().toEmbedded(),
-        subordinate = underenhet,
-    )
+fun EnhetsregisteretOrganization.mapForCreation(): OrganizationDB = OrganizationDB(
+    name = navn,
+    organizationId = organisasjonsnummer,
+    orgType = organisasjonsform?.kode,
+    orgPath = orgPath,
+    subOrganizationOf = overordnetEnhet,
+    municipalityNumber = forretningsadresse?.kommunenummer ?: postadresse?.kommunenummer,
+    issued = registreringsdatoEnhetsregisteret?.let { LocalDate.parse(it) },
+    industryCode = naeringskode1?.kode,
+    sectorCode = institusjonellSektorkode?.kode,
+    homepage = hjemmeside,
+    orgStatus = orgStatusFromDeleteDate(),
+    prefLabel = navn.prefLabelFromName().toEmbedded(),
+    subordinate = underenhet,
+)
 
-fun OrganizationDB.updateValues(org: Organization): OrganizationDB =
-    copy(
-        name = org.name ?: name,
-        internationalRegistry = org.internationalRegistry ?: internationalRegistry,
-        orgType = org.orgType ?: orgType,
-        orgPath = org.orgPath ?: orgPath,
-        subOrganizationOf = org.subOrganizationOf ?: subOrganizationOf,
-        municipalityNumber = org.municipalityNumber ?: municipalityNumber,
-        issued = org.issued ?: issued,
-        industryCode = org.industryCode ?: industryCode,
-        sectorCode = org.sectorCode ?: sectorCode,
-        homepage = org.homepage ?: homepage,
-        prefLabel = (prefLabel?.toPrefLabel() ?: PrefLabel()).update(org.prefLabel).toEmbedded(),
-        subordinate = org.subordinate,
-    )
+fun OrganizationDB.updateValues(org: Organization): OrganizationDB = copy(
+    name = org.name ?: name,
+    internationalRegistry = org.internationalRegistry ?: internationalRegistry,
+    orgType = org.orgType ?: orgType,
+    orgPath = org.orgPath ?: orgPath,
+    subOrganizationOf = org.subOrganizationOf ?: subOrganizationOf,
+    municipalityNumber = org.municipalityNumber ?: municipalityNumber,
+    issued = org.issued ?: issued,
+    industryCode = org.industryCode ?: industryCode,
+    sectorCode = org.sectorCode ?: sectorCode,
+    homepage = org.homepage ?: homepage,
+    prefLabel = (prefLabel?.toPrefLabel() ?: PrefLabel()).update(org.prefLabel).toEmbedded(),
+    subordinate = org.subordinate,
+)
 
 fun OrganizationDB.updateWithEnhetsregisteretValues(
     org: EnhetsregisteretOrganization,
@@ -103,29 +100,26 @@ fun OrganizationDB.updateWithEnhetsregisteretValues(
     )
 }
 
-fun TransportOrganization.prefLabelToUpdate(existingData: OrganizationPrefLabel?): OrganizationPrefLabel? =
-    when {
-        tradingName.isNullOrEmpty() -> null
-        existingData?.value?.nb.isNullOrEmpty() -> toDB()
-        existingData?.value?.nb != tradingName -> toDB()
-        else -> null
-    }
+fun TransportOrganization.prefLabelToUpdate(existingData: OrganizationPrefLabel?): OrganizationPrefLabel? = when {
+    tradingName.isNullOrEmpty() -> null
+    existingData?.value?.nb.isNullOrEmpty() -> toDB()
+    existingData?.value?.nb != tradingName -> toDB()
+    else -> null
+}
 
-fun PrefLabel?.isNullOrEmpty(): Boolean =
-    when {
-        this == null -> true
-        !en.isNullOrBlank() -> false
-        !nb.isNullOrBlank() -> false
-        !nn.isNullOrBlank() -> false
-        else -> true
-    }
+fun PrefLabel?.isNullOrEmpty(): Boolean = when {
+    this == null -> true
+    !en.isNullOrBlank() -> false
+    !nb.isNullOrBlank() -> false
+    !nn.isNullOrBlank() -> false
+    else -> true
+}
 
-private fun PrefLabel.update(newValues: PrefLabel?): PrefLabel =
-    copy(
-        nb = newValues?.nb ?: nb,
-        nn = newValues?.nn ?: nn,
-        en = newValues?.en ?: en,
-    )
+private fun PrefLabel.update(newValues: PrefLabel?): PrefLabel = copy(
+    nb = newValues?.nb ?: nb,
+    nn = newValues?.nn ?: nn,
+    en = newValues?.en ?: en,
+)
 
 private fun EnhetsregisteretOrganization.orgStatusFromDeleteDate(): OrgStatus {
     val today = LocalDate.now()

--- a/src/main/kotlin/no/digdir/organizationcatalog/mapping/OrgPathMapper.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/mapping/OrgPathMapper.kt
@@ -1,10 +1,6 @@
 package no.digdir.organizationcatalog.mapping
 
-fun createOrgPath(
-    isTest: Boolean,
-    orgIdSet: Set<String>,
-    topOrgForm: String?,
-): String {
+fun createOrgPath(isTest: Boolean, orgIdSet: Set<String>, topOrgForm: String?): String {
     val orgPathBase = if (isTest) "/ANNET" else getOrgPathBase(topOrgForm)
     val idString =
         orgIdSet
@@ -13,16 +9,12 @@ fun createOrgPath(
     return "$orgPathBase/$idString"
 }
 
-fun cutOrgPathForParents(
-    orgPath: String,
-    orgNmbr: String,
-) = "${orgPath.split(orgNmbr)[0]}$orgNmbr"
+fun cutOrgPathForParents(orgPath: String, orgNmbr: String) = "${orgPath.split(orgNmbr)[0]}$orgNmbr"
 
-fun getOrgPathBase(topOrgForm: String?): String =
-    when (topOrgForm) {
-        "STAT" -> "/STAT"
-        "FYLK" -> "/FYLKE"
-        "KOMM" -> "/KOMMUNE"
-        "IKS" -> "/ANNET"
-        else -> "/PRIVAT"
-    }
+fun getOrgPathBase(topOrgForm: String?): String = when (topOrgForm) {
+    "STAT" -> "/STAT"
+    "FYLK" -> "/FYLKE"
+    "KOMM" -> "/KOMMUNE"
+    "IKS" -> "/ANNET"
+    else -> "/PRIVAT"
+}

--- a/src/main/kotlin/no/digdir/organizationcatalog/model/OrgStatus.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/model/OrgStatus.kt
@@ -1,8 +1,6 @@
 package no.digdir.organizationcatalog.model
 
-enum class OrgStatus(
-    name: String,
-) {
+enum class OrgStatus(name: String) {
     NORMAL("Normal activity"),
     LIQUIDATED("Liquidated"),
 }

--- a/src/main/kotlin/no/digdir/organizationcatalog/model/OrganizationEnhetsregisteret.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/model/OrganizationEnhetsregisteret.kt
@@ -20,24 +20,16 @@ data class EnhetsregisteretOrganization(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class EnhetsregisteretEmbeddedWrapperDTO(
-    val _embedded: EnhetsregisteretLists?,
-)
+data class EnhetsregisteretEmbeddedWrapperDTO(val _embedded: EnhetsregisteretLists?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class EnhetsregisteretLists(
-    val enheter: List<EnhetsregisteretOrganization> = emptyList(),
-)
+data class EnhetsregisteretLists(val enheter: List<EnhetsregisteretOrganization> = emptyList())
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class EnhetsregisteretCode(
-    val kode: String?,
-)
+data class EnhetsregisteretCode(val kode: String?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class EnhetsregisteretAddress(
-    val kommunenummer: String?,
-)
+data class EnhetsregisteretAddress(val kommunenummer: String?)
 
 enum class EnhetsregisteretType {
     STAT,

--- a/src/main/kotlin/no/digdir/organizationcatalog/model/OrganizationPrefLabel.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/model/OrganizationPrefLabel.kt
@@ -22,10 +22,7 @@ data class OrganizationPrefLabel(
         get() = PrefLabel(nb = nb, nn = nn, en = en)
 }
 
-fun OrganizationPrefLabel(
-    organizationId: String,
-    value: PrefLabel,
-) = OrganizationPrefLabel(
+fun OrganizationPrefLabel(organizationId: String, value: PrefLabel) = OrganizationPrefLabel(
     organizationId = organizationId,
     nb = value.nb,
     nn = value.nn,

--- a/src/main/kotlin/no/digdir/organizationcatalog/model/PrefLabel.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/model/PrefLabel.kt
@@ -5,11 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-data class PrefLabel(
-    val nb: String? = null,
-    val nn: String? = null,
-    val en: String? = null,
-)
+data class PrefLabel(val nb: String? = null, val nn: String? = null, val en: String? = null)
 
 fun PrefLabel.toEmbedded() = EmbeddedPrefLabel(nb = nb, nn = nn, en = en)
 

--- a/src/main/kotlin/no/digdir/organizationcatalog/model/TransportOrganization.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/model/TransportOrganization.kt
@@ -41,13 +41,12 @@ data class Organizations(
     var operators: MutableList<TransportOrganization> = mutableListOf(),
 )
 
-fun TransportOrganization.toDB() =
-    OrganizationPrefLabel(
-        organizationId = this.companyNumber ?: "",
-        value =
-            PrefLabel(
-                nb = (this.tradingName ?: "").trim(),
-            ),
-    )
+fun TransportOrganization.toDB() = OrganizationPrefLabel(
+    organizationId = this.companyNumber ?: "",
+    value =
+    PrefLabel(
+        nb = (this.tradingName ?: "").trim(),
+    ),
+)
 
 fun Iterable<TransportOrganization>.toDB() = this.map { it.toDB() }

--- a/src/main/kotlin/no/digdir/organizationcatalog/security/SecurityConfig.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/security/SecurityConfig.kt
@@ -57,11 +57,19 @@ class SecurityConfig(
 
     @Bean
     fun jwtDecoder(properties: OAuth2ResourceServerProperties): JwtDecoder {
-        val jwtDecoder = NimbusJwtDecoder.withJwkSetUri(properties.jwt.jwkSetUri).build()
+        val jwkSetUri =
+            requireNotNull(properties.jwt.jwkSetUri) {
+                "spring.security.oauth2.resourceserver.jwt.jwk-set-uri must be set"
+            }
+        val issuerUri =
+            requireNotNull(properties.jwt.issuerUri) {
+                "spring.security.oauth2.resourceserver.jwt.issuer-uri must be set"
+            }
+        val jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build()
         jwtDecoder.setJwtValidator(
             DelegatingOAuth2TokenValidator(
                 JwtTimestampValidator(),
-                JwtIssuerValidator(properties.jwt.issuerUri),
+                JwtIssuerValidator(issuerUri),
                 JwtClaimValidator(AUD) { aud: List<String> -> aud.contains("organization-catalog") },
             ),
         )

--- a/src/main/kotlin/no/digdir/organizationcatalog/service/OrganizationCatalogService.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/service/OrganizationCatalogService.kt
@@ -31,19 +31,13 @@ class OrganizationCatalogService(
     private val transportOrganizationAdapter: TransportOrganizationAdapter,
     private val appProperties: AppProperties,
 ) {
-    fun getByOrgnr(orgId: String): Organization? =
-        repository
-            .findById(orgId)
-            .orElse(null)
-            ?.mapToGenerated(appProperties.enhetsregisteretUrl)
-            ?: updateEntryFromEnhetsregisteret(orgId)
+    fun getByOrgnr(orgId: String): Organization? = repository
+        .findById(orgId)
+        .orElse(null)
+        ?.mapToGenerated(appProperties.enhetsregisteretUrl)
+        ?: updateEntryFromEnhetsregisteret(orgId)
 
-    fun getOrganizations(
-        name: String?,
-        orgIds: List<String>?,
-        orgPath: String?,
-        includeSubordinate: Boolean,
-    ): List<Organization> {
+    fun getOrganizations(name: String?, orgIds: List<String>?, orgPath: String?, includeSubordinate: Boolean): List<Organization> {
         val organizations =
             when {
                 name != null && orgIds != null -> searchForOrganizationsByNameAndIds(name, orgIds)
@@ -57,25 +51,19 @@ class OrganizationCatalogService(
             .filter { if (includeSubordinate) true else !it.subordinate }
     }
 
-    private fun getCatalog() =
-        repository
-            .findAll()
-            .map { it.mapToGenerated(appProperties.enhetsregisteretUrl) }
+    private fun getCatalog() = repository
+        .findAll()
+        .map { it.mapToGenerated(appProperties.enhetsregisteretUrl) }
 
-    private fun searchForOrganizationsByIds(orgs: List<String>) =
-        repository
-            .findAllById(orgs)
-            .map { it.mapToGenerated(appProperties.enhetsregisteretUrl) }
+    private fun searchForOrganizationsByIds(orgs: List<String>) = repository
+        .findAllById(orgs)
+        .map { it.mapToGenerated(appProperties.enhetsregisteretUrl) }
 
-    private fun searchForOrganizationsByName(name: String) =
-        repository
-            .findByNameContainingIgnoreCase(name)
-            .map { it.mapToGenerated(appProperties.enhetsregisteretUrl) }
+    private fun searchForOrganizationsByName(name: String) = repository
+        .findByNameContainingIgnoreCase(name)
+        .map { it.mapToGenerated(appProperties.enhetsregisteretUrl) }
 
-    private fun searchForOrganizationsByNameAndIds(
-        name: String,
-        orgs: List<String>,
-    ) = repository
+    private fun searchForOrganizationsByNameAndIds(name: String, orgs: List<String>) = repository
         .findByNameContainingIgnoreCase(name)
         .filter { orgs.contains(it.organizationId) }
         .map { it.mapToGenerated(appProperties.enhetsregisteretUrl) }
@@ -102,25 +90,20 @@ class OrganizationCatalogService(
             ?: mapForCreation()
     }
 
-    fun updateEntry(
-        orgId: String,
-        org: Organization,
-    ): Organization? =
-        repository
-            .findById(orgId)
-            .orElse(null)
-            ?.updateValues(org)
-            ?.let { repository.save(it) }
-            ?.mapToGenerated(appProperties.enhetsregisteretUrl)
+    fun updateEntry(orgId: String, org: Organization): Organization? = repository
+        .findById(orgId)
+        .orElse(null)
+        ?.updateValues(org)
+        ?.let { repository.save(it) }
+        ?.mapToGenerated(appProperties.enhetsregisteretUrl)
 
-    fun getOrgPath(orgId: String): String =
-        if (orgId.isOrganizationNumber()) {
-            getByOrgnr(orgId)
-                ?.orgPath
-                ?: "${appProperties.defaultOrgPath}$orgId"
-        } else {
-            "${appProperties.defaultOrgPath}$orgId"
-        }
+    fun getOrgPath(orgId: String): String = if (orgId.isOrganizationNumber()) {
+        getByOrgnr(orgId)
+            ?.orgPath
+            ?: "${appProperties.defaultOrgPath}$orgId"
+    } else {
+        "${appProperties.defaultOrgPath}$orgId"
+    }
 
     private fun EnhetsregisteretOrganization.addOrgPath(): EnhetsregisteretOrganization {
         val orgPathBase =
@@ -134,17 +117,16 @@ class OrganizationCatalogService(
     }
 
     @Scheduled(cron = "0 30 18 9 * ?")
-    fun updateTransportData(): Unit =
-        transportOrganizationAdapter
-            .downloadTransportDataList()
-            .filter { it.companyNumber != null }
-            .mapNotNull {
-                it.prefLabelToUpdate(
-                    organizationPrefLabelRepository.findById(it.companyNumber!!).orElse(null),
-                )
-            }.run {
-                if (this.isNotEmpty()) organizationPrefLabelRepository.saveAll(this)
-            }
+    fun updateTransportData(): Unit = transportOrganizationAdapter
+        .downloadTransportDataList()
+        .filter { it.companyNumber != null }
+        .mapNotNull {
+            it.prefLabelToUpdate(
+                organizationPrefLabelRepository.findById(it.companyNumber!!).orElse(null),
+            )
+        }.run {
+            if (this.isNotEmpty()) organizationPrefLabelRepository.saveAll(this)
+        }
 
     @Scheduled(cron = "0 30 20 9 * ?")
     fun updateAllEntriesFromEnhetsregisteret() {

--- a/src/main/kotlin/no/digdir/organizationcatalog/utils/Utils.kt
+++ b/src/main/kotlin/no/digdir/organizationcatalog/utils/Utils.kt
@@ -15,31 +15,29 @@ fun String.isOrganizationNumber(): Boolean {
     return regex.containsMatchIn(this)
 }
 
-fun String.prefLabelFromName(): PrefLabel =
-    PrefLabel(
-        nb =
-            this
-                .lowercase(Locale.getDefault())
-                .replaceFirstChar { it.titlecase(Locale.getDefault()) },
-    )
+fun String.prefLabelFromName(): PrefLabel = PrefLabel(
+    nb =
+    this
+        .lowercase(Locale.getDefault())
+        .replaceFirstChar { it.titlecase(Locale.getDefault()) },
+)
 
-fun String.transformToTransportDataList(): List<TransportOrganization> =
-    this.let {
-        val serializer = Persister()
-        try {
-            val publicationDelivery = serializer.read(PublicationDelivery::class.java, this)
-            logger.info("PublicationDelivery parsed: $publicationDelivery")
+fun String.transformToTransportDataList(): List<TransportOrganization> = this.let {
+    val serializer = Persister()
+    try {
+        val publicationDelivery = serializer.read(PublicationDelivery::class.java, this)
+        logger.info("PublicationDelivery parsed: $publicationDelivery")
 
-            val organisations =
-                publicationDelivery
-                    ?.dataObjects
-                    ?.resourceFrame
-                    ?.organisations
+        val organisations =
+            publicationDelivery
+                ?.dataObjects
+                ?.resourceFrame
+                ?.organisations
 
-            return@let (organisations?.authorities ?: emptyList()) +
-                (organisations?.operators ?: emptyList())
-        } catch (ex: Exception) {
-            logger.error("Error transforming xml data : ${ex.message}")
-        }
-        return@let emptyList()
+        return@let (organisations?.authorities ?: emptyList()) +
+            (organisations?.operators ?: emptyList())
+    } catch (ex: Exception) {
+        logger.error("Error transforming xml data : ${ex.message}")
     }
+    return@let emptyList()
+}

--- a/src/test/kotlin/no/digdir/organizationcatalog/contract/TransportDataTest.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/contract/TransportDataTest.kt
@@ -96,9 +96,9 @@ class TransportDataTest : ApiTestContext() {
             OrganizationPrefLabel(
                 organizationId = orgId,
                 value =
-                    PrefLabel(
-                        nb = "Old Name",
-                    ),
+                PrefLabel(
+                    nb = "Old Name",
+                ),
             )
         organizationPrefLabelRepository.save(oldTransportDb)
         organizationCatalogService.updateTransportData()

--- a/src/test/kotlin/no/digdir/organizationcatalog/mapping/UpdateFromEnhetsregisteret.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/mapping/UpdateFromEnhetsregisteret.kt
@@ -17,10 +17,10 @@ class UpdateFromEnhetsregisteret {
         val orgWithNN =
             ORG_DB1.copy(
                 prefLabel =
-                    EmbeddedPrefLabel(
-                        nb = "Forsvaret på bokmål",
-                        nn = "Forsvaret på nynorsk",
-                    ),
+                EmbeddedPrefLabel(
+                    nb = "Forsvaret på bokmål",
+                    nn = "Forsvaret på nynorsk",
+                ),
             )
 
         val expectedNb = "Forsvaret på bokmål"
@@ -38,10 +38,10 @@ class UpdateFromEnhetsregisteret {
         val orgWithNN =
             ORG_DB1.copy(
                 prefLabel =
-                    EmbeddedPrefLabel(
-                        nb = "Forsvaret på bokmål",
-                        nn = "Forsvaret på nynorsk",
-                    ),
+                EmbeddedPrefLabel(
+                    nb = "Forsvaret på bokmål",
+                    nn = "Forsvaret på nynorsk",
+                ),
             )
 
         val expectedNb = "Forsvaret på bokmål"
@@ -60,10 +60,10 @@ class UpdateFromEnhetsregisteret {
             ORG_DB1.copy(
                 name = "FØRSVARET",
                 prefLabel =
-                    EmbeddedPrefLabel(
-                        nb = "Førsvaret",
-                        nn = "Føresvaret",
-                    ),
+                EmbeddedPrefLabel(
+                    nb = "Førsvaret",
+                    nn = "Føresvaret",
+                ),
             )
 
         val expectedNb = "Forsvaret"

--- a/src/test/kotlin/no/digdir/organizationcatalog/utils/Expect.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/utils/Expect.kt
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Assertions
 /**
  * Expect assertion style wrapper for jupiter assertions
  */
-class Expect(
-    _result: Any?,
-) {
+class Expect(_result: Any?) {
     private val responseReader = TestResponseReader()
 
     val result = _result
@@ -24,10 +22,7 @@ class Expect(
         }
     }
 
-    fun isomorphic_with_response_in_file(
-        filename: String,
-        resultLang: String,
-    ) {
+    fun isomorphic_with_response_in_file(filename: String, resultLang: String) {
         val resultModel = responseReader.parseResponse(result as String, resultLang)
         val expectedModel = responseReader.getExpectedResponse(filename, "TURTLE")
 

--- a/src/test/kotlin/no/digdir/organizationcatalog/utils/Expect.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/utils/Expect.kt
@@ -1,11 +1,10 @@
 package no.digdir.organizationcatalog.utils
 
+import org.junit.jupiter.api.Assertions
+
 /**
  * Expect assertion style wrapper for jupiter assertions
  */
-
-import org.junit.jupiter.api.Assertions
-
 class Expect(
     _result: Any?,
 ) {

--- a/src/test/kotlin/no/digdir/organizationcatalog/utils/TestData.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/utils/TestData.kt
@@ -15,10 +15,7 @@ const val WIREMOCK_TEST_HOST = "http://localhost:5050"
 
 const val ENHETSREGISTERET_URL = "$WIREMOCK_TEST_HOST/enhetsregisteret/api/enheter/"
 
-fun getApiAddress(
-    port: Int,
-    endpoint: String,
-): String = "http://localhost:$port$endpoint"
+fun getApiAddress(port: Int, endpoint: String): String = "http://localhost:$port$endpoint"
 
 val ORG_0 =
     Organization(
@@ -34,9 +31,9 @@ val ORG_0 =
         sectorCode = "6100",
         homepage = "www.brreg.no",
         prefLabel =
-            PrefLabel(
-                nb = "Brønnøysundregistrene",
-            ),
+        PrefLabel(
+            nb = "Brønnøysundregistrene",
+        ),
         orgStatus = OrgStatus.NORMAL,
     )
 
@@ -83,11 +80,11 @@ val NOT_UPDATED_0 =
         industryCode = "84.220",
         sectorCode = "6100",
         prefLabel =
-            PrefLabel(
-                nb = "nbNotUpdated",
-                nn = "nnNotUpdated",
-                en = "enNotUpdated",
-            ),
+        PrefLabel(
+            nb = "nbNotUpdated",
+            nn = "nnNotUpdated",
+            en = "enNotUpdated",
+        ),
         orgStatus = OrgStatus.NORMAL,
     )
 
@@ -118,11 +115,11 @@ val UPDATE_VALUES =
         industryCode = "industryUriUpdated",
         sectorCode = "sectorUriUpdated",
         prefLabel =
-            PrefLabel(
-                nb = "nbLabelUpdated",
-                nn = "nnLabelUpdated",
-                en = "enLabelUpdated",
-            ),
+        PrefLabel(
+            nb = "nbLabelUpdated",
+            nn = "nnLabelUpdated",
+            en = "enLabelUpdated",
+        ),
         orgStatus = OrgStatus.NORMAL,
     )
 
@@ -138,11 +135,11 @@ val UPDATED_0 =
         industryCode = "84.220",
         sectorCode = "6100",
         prefLabel =
-            PrefLabel(
-                nb = "nbNotUpdated",
-                nn = "nnNotUpdated",
-                en = "enNotUpdated",
-            ),
+        PrefLabel(
+            nb = "nbNotUpdated",
+            nn = "nnNotUpdated",
+            en = "enNotUpdated",
+        ),
         orgStatus = OrgStatus.NORMAL,
     )
 
@@ -159,11 +156,11 @@ val UPDATED_1 =
         industryCode = "industryUriUpdated",
         sectorCode = "sectorUriUpdated",
         prefLabel =
-            PrefLabel(
-                nb = "nbLabelUpdated",
-                nn = "nnLabelUpdated",
-                en = "enLabelUpdated",
-            ),
+        PrefLabel(
+            nb = "nbLabelUpdated",
+            nn = "nnLabelUpdated",
+            en = "enLabelUpdated",
+        ),
         orgStatus = OrgStatus.NORMAL,
     )
 
@@ -298,32 +295,30 @@ data class TestOrg(
     val subordinate: Boolean = false,
 )
 
-fun organizationsDBPopulation(): List<TestOrg> =
-    listOf(
-        ORG_0,
-        ORG_1,
-        ORG_2,
-        NOT_UPDATED_0,
-        NOT_UPDATED_1,
-        ORG_WITH_DOMAIN,
-        ORG_WITHOUT_DOMAIN,
-        NOT_UPDATED_2,
-        PARENT_ORG,
-    ).map { it.toTestOrg() }
+fun organizationsDBPopulation(): List<TestOrg> = listOf(
+    ORG_0,
+    ORG_1,
+    ORG_2,
+    NOT_UPDATED_0,
+    NOT_UPDATED_1,
+    ORG_WITH_DOMAIN,
+    ORG_WITHOUT_DOMAIN,
+    NOT_UPDATED_2,
+    PARENT_ORG,
+).map { it.toTestOrg() }
 
-private fun Organization.toTestOrg(): TestOrg =
-    TestOrg(
-        organizationId = organizationId ?: "",
-        name = name ?: "",
-        orgType = orgType,
-        orgPath = orgPath,
-        subOrganizationOf = subOrganizationOf,
-        issued = issued,
-        municipalityNumber = municipalityNumber,
-        industryCode = industryCode,
-        sectorCode = sectorCode,
-        prefLabel = prefLabel,
-        orgStatus = orgStatus,
-        homepage = homepage,
-        subordinate = subordinate,
-    )
+private fun Organization.toTestOrg(): TestOrg = TestOrg(
+    organizationId = organizationId ?: "",
+    name = name ?: "",
+    orgType = orgType,
+    orgPath = orgPath,
+    subOrganizationOf = subOrganizationOf,
+    issued = issued,
+    municipalityNumber = municipalityNumber,
+    industryCode = industryCode,
+    sectorCode = sectorCode,
+    prefLabel = prefLabel,
+    orgStatus = orgStatus,
+    homepage = homepage,
+    subordinate = subordinate,
+)

--- a/src/test/kotlin/no/digdir/organizationcatalog/utils/TestResponseReader.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/utils/TestResponseReader.kt
@@ -11,19 +11,13 @@ class TestResponseReader {
     private fun resourceAsReader(resourceName: String): Reader =
         InputStreamReader(javaClass.classLoader.getResourceAsStream(resourceName)!!, StandardCharsets.UTF_8)
 
-    fun getExpectedResponse(
-        filename: String,
-        lang: String,
-    ): Model {
+    fun getExpectedResponse(filename: String, lang: String): Model {
         val expected = ModelFactory.createDefaultModel()
         expected.read(resourceAsReader("responses/$filename"), "", lang)
         return expected
     }
 
-    fun parseResponse(
-        response: String,
-        lang: String,
-    ): Model {
+    fun parseResponse(response: String, lang: String): Model {
         val responseModel = ModelFactory.createDefaultModel()
         responseModel.read(StringReader(response), "", lang)
         return responseModel

--- a/src/test/kotlin/no/digdir/organizationcatalog/utils/TestUtils.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/utils/TestUtils.kt
@@ -7,12 +7,7 @@ import java.net.HttpURLConnection
 import java.net.URI
 import java.sql.DriverManager
 
-fun apiGet(
-    endpoint: String,
-    port: Int,
-    acceptHeader: String?,
-    otherHeaders: List<Pair<String, String>> = emptyList(),
-): Map<String, Any> =
+fun apiGet(endpoint: String, port: Int, acceptHeader: String?, otherHeaders: List<Pair<String, String>> = emptyList()): Map<String, Any> =
     try {
         val connection = URI(getApiAddress(port, endpoint)).toURL().openConnection() as HttpURLConnection
         acceptHeader?.let { connection.addRequestProperty("Accept", it) }
@@ -41,57 +36,49 @@ fun apiGet(
         )
     }
 
-fun apiAuthorizedRequest(
-    endpoint: String,
-    port: Int,
-    body: String?,
-    token: String?,
-    method: String,
-): Map<String, Any> =
-    try {
-        val connection = URI("http://localhost:$port$endpoint").toURL().openConnection() as HttpURLConnection
-        connection.requestMethod = method
-        connection.setRequestProperty("Content-type", "application/json")
-        connection.setRequestProperty("Accept", "application/json")
-        if (!token.isNullOrEmpty()) connection.setRequestProperty("Authorization", "Bearer $token")
+fun apiAuthorizedRequest(endpoint: String, port: Int, body: String?, token: String?, method: String): Map<String, Any> = try {
+    val connection = URI("http://localhost:$port$endpoint").toURL().openConnection() as HttpURLConnection
+    connection.requestMethod = method
+    connection.setRequestProperty("Content-type", "application/json")
+    connection.setRequestProperty("Accept", "application/json")
+    if (!token.isNullOrEmpty()) connection.setRequestProperty("Authorization", "Bearer $token")
 
-        connection.doOutput = true
-        connection.connect()
+    connection.doOutput = true
+    connection.connect()
 
-        if (body != null) {
-            val writer = OutputStreamWriter(connection.outputStream)
-            writer.write(body)
-            writer.close()
-        }
+    if (body != null) {
+        val writer = OutputStreamWriter(connection.outputStream)
+        writer.write(body)
+        writer.close()
+    }
 
-        if (isOK(connection.responseCode)) {
-            val responseBody = connection.inputStream.bufferedReader().use(BufferedReader::readText)
-            mapOf(
-                "body" to responseBody,
-                "header" to connection.headerFields.toString(),
-                "status" to connection.responseCode,
-            )
-        } else {
-            mapOf(
-                "status" to connection.responseCode,
-                "header" to " ",
-                "body" to " ",
-            )
-        }
-    } catch (e: Exception) {
+    if (isOK(connection.responseCode)) {
+        val responseBody = connection.inputStream.bufferedReader().use(BufferedReader::readText)
         mapOf(
-            "status" to e.toString(),
+            "body" to responseBody,
+            "header" to connection.headerFields.toString(),
+            "status" to connection.responseCode,
+        )
+    } else {
+        mapOf(
+            "status" to connection.responseCode,
             "header" to " ",
             "body" to " ",
         )
     }
+} catch (e: Exception) {
+    mapOf(
+        "status" to e.toString(),
+        "header" to " ",
+        "body" to " ",
+    )
+}
 
-private fun isOK(response: Int?): Boolean =
-    if (response == null) {
-        false
-    } else {
-        HttpStatus.resolve(response)?.is2xxSuccessful == true
-    }
+private fun isOK(response: Int?): Boolean = if (response == null) {
+    false
+} else {
+    HttpStatus.resolve(response)?.is2xxSuccessful == true
+}
 
 fun resetDB() {
     val container = ApiTestContext.postgresContainer
@@ -133,7 +120,4 @@ fun resetDB() {
     }
 }
 
-data class JenaAndHeader(
-    val acceptHeader: String,
-    val jenaType: String,
-)
+data class JenaAndHeader(val acceptHeader: String, val jenaType: String)

--- a/src/test/kotlin/no/digdir/organizationcatalog/utils/jwk/JwtToken.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/utils/jwk/JwtToken.kt
@@ -4,9 +4,7 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import java.util.Date
 
-class JwtToken(
-    private val access: Access,
-) {
+class JwtToken(private val access: Access) {
     private val exp = Date().time + 120 * 1000
     private val aud = listOf("organization-catalog")
 
@@ -33,9 +31,7 @@ class JwtToken(
     override fun toString(): String = buildToken()
 }
 
-enum class Access(
-    val authorities: String,
-) {
+enum class Access(val authorities: String) {
     ORG_READ("organization:910244132:read"),
     ORG_WRITE("organization:910244132:admin"),
     ROOT("system:root:admin"),

--- a/src/test/kotlin/no/digdir/organizationcatalog/utils/jwk/JwtUtils.kt
+++ b/src/test/kotlin/no/digdir/organizationcatalog/utils/jwk/JwtUtils.kt
@@ -14,12 +14,11 @@ import java.util.UUID
 object JwkStore {
     private val jwk = createJwk()
 
-    private fun createJwk(): RSAKey =
-        RSAKeyGenerator(2048)
-            .algorithm(JWSAlgorithm.RS256)
-            .keyUse(KeyUse.SIGNATURE)
-            .keyID(UUID.randomUUID().toString())
-            .generate()
+    private fun createJwk(): RSAKey = RSAKeyGenerator(2048)
+        .algorithm(JWSAlgorithm.RS256)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID(UUID.randomUUID().toString())
+        .generate()
 
     fun get(): String {
         val token: JwkToken =
@@ -28,23 +27,16 @@ object JwkStore {
         return token.toString()
     }
 
-    fun jwtHeader() =
-        JWSHeader
-            .Builder(JWSAlgorithm.RS256)
-            .keyID(jwk.keyID)
-            .build()
+    fun jwtHeader() = JWSHeader
+        .Builder(JWSAlgorithm.RS256)
+        .keyID(jwk.keyID)
+        .build()
 
     fun signer() = RSASSASigner(jwk)
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class JwkToken(
-    private val kid: String,
-    private val kty: String,
-    private val use: String,
-    private val n: String,
-    private val e: String,
-) {
+class JwkToken(private val kid: String, private val kty: String, private val use: String, private val n: String, private val e: String) {
     override fun toString(): String =
         """
         {


### PR DESCRIPTION
# Summary 

- Bump Spring Boot 4.0.5 -> 4.1.0, pulling in Tomcat 11.0.22, Spring Framework 7.0.8, Jackson 2.21.4/3.1.4 and spring-data-commons 4.1.0, which clears the Tomcat auth-bypass CVEs and CVE-2026-40976.
- Pin postgresql 42.7.13, overriding Spring Boot 4.1.0's 42.7.11, which is still affected by CVE-2026-54291.
- Adapt `SecurityConfig` to Spring Framework 7.0.8, where `OAuth2ResourceServerProperties.jwt.jwkSetUri` and `.issuerUri` became nullable.
- Bump ktlint-maven-plugin 3.5.0 -> 3.7.1 via a `ktlint.version` property. Contrary to the sibling services, ktlint was already inspecting every Kotlin file here: `<sourceDirectory>`/`<testSourceDirectory>` already point at `src/main/kotlin` and `src/test/kotlin`, so no build-helper source registration was needed. Verified with a deliberately malformed function in both source sets.
- Fix the one violation the 3.7.1 rule set reports (dangling top-level KDoc in `Expect.kt`) and accept its `when`-entry bracing auto-format in `OrganizationsController`.
- Extend `.editorconfig` with a repo-wide default section, a 140-char Kotlin line limit and 2-space indent for xml/yaml/json.
