### PR TITLE
fix: bump jena to 6.2.0 for libthrift CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
         <kotlin.version>2.2.21</kotlin.version>
         <testcontainers.version>2.0.4</testcontainers.version>
-        <jena.version>6.0.0</jena.version>
+        <jena.version>6.2.0</jena.version>
         <ktlint.version>3.7.1</ktlint.version>
         <!-- Overrides Spring Boot 4.1.0 (42.7.11), which is still affected by CVE-2026-54291 -->
         <postgresql.version>42.7.13</postgresql.version>


### PR DESCRIPTION
# Summary 

- Bump `jena.version` from 6.0.0 to 6.2.0, which pins `org.apache.thrift:libthrift` 0.24.0 instead of the vulnerable 0.22.0.
- Resolves the last remaining CRITICAL/HIGH Trivy app-dependency finding in this repo.
- No source changes needed; full `mvn clean verify` passes (18 unit + 45 integration tests), including the RDF graph-isomorphism contract tests.
